### PR TITLE
本番環境リロード時にfontawesomeのアイコンが拡大表示されないようにする

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -12,6 +12,7 @@ module.exports = {
   plugins: [
     `gatsby-plugin-typescript`,
     `gatsby-plugin-sass`,
+    `gatsby-plugin-fontawesome-css`,
     `gatsby-transformer-remark`,
     {
       resolve: `gatsby-source-filesystem`,

--- a/package-lock.json
+++ b/package-lock.json
@@ -7514,6 +7514,11 @@
         "micromatch": "^3.1.10"
       }
     },
+    "gatsby-plugin-fontawesome-css": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/gatsby-plugin-fontawesome-css/-/gatsby-plugin-fontawesome-css-1.0.0.tgz",
+      "integrity": "sha512-jToy7WSlNjCtcFWjS7/W1U8jJggKBv2hZhatYyNXELfxvl3eFvuJGlDYYDDKtMzv57N5hbXwUvJ+iW21+FcDOA=="
+    },
     "gatsby-plugin-manifest": {
       "version": "2.4.26",
       "resolved": "https://registry.npmjs.org/gatsby-plugin-manifest/-/gatsby-plugin-manifest-2.4.26.tgz",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "@fortawesome/free-solid-svg-icons": "^5.14.0",
     "@fortawesome/react-fontawesome": "^0.1.11",
     "gatsby": "^2.24.47",
+    "gatsby-plugin-fontawesome-css": "^1.0.0",
     "gatsby-plugin-manifest": "^2.4.26",
     "gatsby-plugin-sass": "^2.3.12",
     "gatsby-plugin-typescript": "^2.4.18",


### PR DESCRIPTION
## 概要
- 本番環境リロード時にfontawesomeのアイコンが拡大表示されていたので修正
https://github.com/dak2/my-blog/issues/8

## 原因
- リロード時にJavaScriptファイル実行されるタイミングで、fontawesomeがページに合うように自動的にCSSスタイルを入れ込んでいる
  - スタイルを入れ込む間にスタイル無しのアイコンが表示されてしまう

## やったこと
- [x] gatsby-plugin-fontawesome-css パッケージをインストールしてコンパイル時に自動的にCSSスタイルを入れ込むようにする